### PR TITLE
Update GitHub repository URL

### DIFF
--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="action_settings">Nastavení</string>
     <string name="app_name">AutoScreenOnOff</string>
-    <string name="author_url">https://github.com/plateaukao/PowerOff</string>
+    <string name="author_url">https://github.com/plateaukao/AutoScreenOnOff</string>
     <string name="changelog_html">
         <![CDATA[
         <b>Version 2.3 (2014/02/14)</b>
@@ -44,7 +44,7 @@ v%s"</string>
     <string name="pref_summary_timeout_lock">"Zpoždění než se Obrazovka Vypne.
 
 Aktuální nastavení:%s"</string>
-    <string name="pref_summary_timeout_unlock">"Zpoždění než se Obrazovka Zapne. 
+    <string name="pref_summary_timeout_unlock">"Zpoždění než se Obrazovka Zapne.
 
 Aktuální nastavení:%s"</string>
     <string name="pref_title_auto_on">Povolit</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -149,7 +149,7 @@
     <string name="statusbar_autoscreen_off">Extinction automatique désactivée</string>
 
     <!-- no translation -->
-    <string name="author_url">https://github.com/plateaukao/PowerOff</string>
+    <string name="author_url">https://github.com/plateaukao/AutoScreenOnOff</string>
     <string name="playstore_url">https://play.google.com/store/apps/details?id=com.danielkao.autoscreenonoff</string>
     <string name="pref_play_close_sound">Joue un son lors de l\'extinction automatique de l\'écran</string>
     <string name="pref_title_play_close_sound">Écouter le son</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -115,7 +115,7 @@
     <string name="statusbar_autoscreen_off">AutoScreen is Gedeactiveerd.</string>
 
     <!-- no translation -->
-    <string name="author_url">https://github.com/plateaukao/PowerOff</string>
+    <string name="author_url">https://github.com/plateaukao/AutoScreenOnOff</string>
     <string name="playstore_url">https://play.google.com/store/apps/details?id=com.danielkao.autoscreenonoff</string>
     <string name="pref_play_close_sound">Speel geluid wanner scherm uit is.</string>
     <string name="pref_title_play_close_sound">Play Close Sound</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -149,7 +149,7 @@
     <string name="statusbar_autoscreen_off">AutoScreen nie je aktívny.</string>
 
     <!-- no translation -->
-    <string name="author_url">https://github.com/plateaukao/PowerOff</string>
+    <string name="author_url">https://github.com/plateaukao/AutoScreenOnOff</string>
     <string name="playstore_url">https://play.google.com/store/apps/details?id=com.danielkao.autoscreenonoff</string>
     <string name="pref_play_close_sound">Prehrá zvuk keď sa automaticky vypne obrazovka.</string>
     <string name="pref_title_play_close_sound">Prehrať zvuk</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -144,7 +144,7 @@
     <string name="statusbar_autoscreen_off">Đã dừng màn hình tự động.</string>
 
     <!-- no translation -->
-    <string name="author_url">https://github.com/plateaukao/PowerOff</string>
+    <string name="author_url">https://github.com/plateaukao/AutoScreenOnOff</string>
     <string name="playstore_url">https://play.google.com/store/apps/details?id=com.danielkao.autoscreenonoff</string>
     <string name="pref_play_close_sound">Play sound while auto turning off screen</string>
     <string name="pref_title_play_close_sound">Play Close Sound</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -199,7 +199,7 @@
     <string name="statusbar_autoscreen_off">AutoScreen is disabled.</string>
 
     <!-- no translation -->
-    <string name="author_url">https://github.com/plateaukao/PowerOff</string>
+    <string name="author_url">https://github.com/plateaukao/AutoScreenOnOff</string>
     <string name="playstore_url">https://play.google.com/store/apps/details?id=com.danielkao.autoscreenonoff</string>
 
     <string name="pref_play_close_sound">Play sound while auto turning off screen</string>


### PR DESCRIPTION
Because you renamed the project, the repository URL for the project has
changed. In the browser, GitHub properly redirects to the new repo, but
if a user has the GitHub app installed, it simply says "Loading
repository failed!" because it simply takes the URL and parses that into
an API request. The GitHub API does not handle repository rename
redirects.

See:
http://stackoverflow.com/questions/22715169/github-api-returns-404-but-default-http-request-returns-301
https://github.com/github/android/blob/e18693727bc62bc2598cd7575130cbf3b8f341eb/app/src/main/java/com/github/mobile/ui/repo/RepositoryViewActivity.java#L121
https://github.com/github/android/blob/e18693727bc62bc2598cd7575130cbf3b8f341eb/app/src/main/java/com/github/mobile/core/repo/RefreshRepositoryTask.java#L55
https://github.com/eclipse/egit-github/blob/bcdf39cca5ef0dd828f960030a2febba1e56a253/org.eclipse.egit.github.core/src/org/eclipse/egit/github/core/service/RepositoryService.java#L580-L607
